### PR TITLE
[Canvas]Swaggerの仕様に合わせ、値のないリクエストパラメータは送らないようにした

### DIFF
--- a/dConnectJavascriptApp/js/profile/canvas.js
+++ b/dConnectJavascriptApp/js/profile/canvas.js
@@ -129,7 +129,9 @@ function doCanvasDrawImage(serviceId, fileFormId) {
   var myForm = document.getElementById(fileFormId);
   var myFormData = new FormData(myForm);
   var myXhr = new XMLHttpRequest();
-
+  if (!myFormData.get('mode')) {
+    myFormData.delete('mode');
+  }
   myXhr.open(myForm.method, myForm.action, true);
   myXhr.onreadystatechange = function() {
     if (myXhr.readyState === 4) {


### PR DESCRIPTION
## 更新内容
* Swaggerの仕様に合わせ、値のないパラメータは送らないようにした